### PR TITLE
fix: restart bot on error instead of exiting

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -192,7 +192,11 @@ pub async fn daemon(config: &Option<DaemonConfig>) -> anyhow::Result<()> {
 
     // Run the bot and block
     // It never exits
-    bot.run().await
+    loop {
+        if let Err(e) = bot.run().await {
+            error!("Bot restarting after it exited with error: {e}");
+        }
+    }
 }
 
 /// Sets config options for the room


### PR DESCRIPTION
Hi!

When running this project, I occasionally have the program exit because of a timed out request. This little change restarts the bot on failure instead of making the daemon exit.

Thanks!