### PR TITLE
feat: urgent rooms, emoji tags, JSON deserialization and header fields aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,6 +2153,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.7",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "emojis"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72f23d65b46527e461b161ab9a126c378aa2249d8a8d15718d23ab1fb4d8786"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,6 +2059,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2142,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs",
+ "emojis",
  "headjack",
  "http-body-util",
  "hyper 1.4.1",
@@ -2905,6 +2933,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "urlencoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
 reqwest = "0.12"
+url = "2.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ hyper-util = { version = "0.1", features = ["full"] }
 reqwest = "0.12"
 url = "2.5.2"
 emojis = "0.6.3"
+serde_json = "1.0.128"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
 reqwest = "0.12"
 url = "2.5.2"
+emojis = "0.6.3"

--- a/README.md
+++ b/README.md
@@ -147,8 +147,11 @@ rooms:
   # e.g. `pokem The backup failed!` will send to the default room
   default: "!RoomID:jackson.dev"
   error: "!ErrorRoom:jackson.dev"
-  fullteam: "!RoomWithFullTeam:jackson.dev"
   discord: "!RoomBridgedToDiscord:jackson.dev"
+  fullteam: "!RoomWithFullTeam:jackson.dev"
+  # Messages that come with the "urgent" tag sent to "fullteam" will go to "fullteam-urgent", if
+  # it exists, otherwise they will be sent to "fullteam" with a "@room" ping
+  fullteam-urgent: "!RoomWithFullTeamUrgent:jackson.dev"
 
 # Optional, define the server to send messages to
 # If configured, `pokem` will first try to query this server to send the message

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -48,7 +48,11 @@ impl PokeRequest {
             })
             .unwrap_or_default();
         let poke_request = PokeRequest {
-            title: query_params.get("title").cloned(),
+            title: query_params.get("title").cloned().or_else(|| {
+                headers
+                    .get("x-title")
+                    .and_then(|tags| tags.to_str().ok().map(String::from))
+            }),
             message: query_params.get("message").cloned(),
             priority: query_params
                 .get("priority")

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -53,7 +53,11 @@ impl PokeRequest {
                     .get("x-title")
                     .and_then(|tags| tags.to_str().ok().map(String::from))
             }),
-            message: query_params.get("message").cloned(),
+            message: query_params.get("message").cloned().or_else(|| {
+                headers
+                    .get("x-message")
+                    .and_then(|msg| msg.to_str().ok().map(String::from))
+            }),
             priority: query_params
                 .get("priority")
                 .and_then(|p| p.parse().ok())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,8 +8,7 @@ use matrix_sdk::ruma::events::tag::TagInfo;
 use matrix_sdk::Room;
 
 use tokio::sync::RwLock;
-use tracing::debug;
-use tracing::error;
+use tracing::{debug, error};
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ async fn main() -> anyhow::Result<()> {
         let bot = connect(matrix).await?;
         GLOBAL_BOT.lock().unwrap().replace(bot.clone());
         // Ping the room
-        return ping_room(&bot, &room, &headers, &messages.join(" ")).await;
+        return ping_room(&bot, &room, &headers, &messages.join(" "), false).await;
     }
 
     return Err(anyhow::anyhow!("Unable to send message"));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use headjack::*;
 use matrix_sdk::ruma::events::room::message::RoomMessageEventContent;
 
 use matrix_sdk::ruma::events::tag::TagInfo;
+use matrix_sdk::ruma::events::Mentions;
 use matrix_sdk::{Room, RoomMemberships, RoomState};
 
 use tracing::{error, info};
@@ -173,6 +174,7 @@ pub async fn ping_room(
     room_id: &str,
     headers: &HeaderMap,
     message: &str,
+    mention_room: bool,
 ) -> anyhow::Result<()> {
     let r = get_room_from_name(bot, room_id).await;
     if r.is_none() {
@@ -206,7 +208,10 @@ pub async fn ping_room(
     }
 
     // Get the message formatting
-    let msg = format_message(headers, &msg);
+    let mut msg = format_message(headers, &msg);
+    if mention_room {
+        msg = msg.add_mentions(Mentions::with_room_mention());
+    }
 
     if can_message_room(&r).await {
         if let Err(e) = r.send(msg).await {


### PR DESCRIPTION
Hi!

This PR requires #8.

The goal here is to help users manage priorities. When sending urgent messages (`ntfy send --priority urgent`) to a room called `sampleroom`, if `sampleroom-urgent` exists in the configuration, the message will be sent there, otherwise it will be sent to `sampleroom` with a `@room` tag. This way, users can either:
- only have `sampleroom` and restrict notifications to pings: they will hence get the noisy notification only for urgent messages
- have `sampleroom` for classic messages, which can be silenced (like without vibration or sound on Android) and `sampleroom-urgent` with full vibrations and sounds for urgent messages.

The urgent flag is something used by many NTFY clients, so this should make interoperability between the two easier.

Thanks!